### PR TITLE
fix: solana rpc websocket url not working

### DIFF
--- a/packages/solana/src/solana.ts
+++ b/packages/solana/src/solana.ts
@@ -72,7 +72,7 @@ const fetchTokenInfo = async (params: TokenRequestParams) => {
 const createProvider = async (url: string) => {
   let solanaConnectionObject: Connection | undefined
   if (solanaConnectionObject?.rpcEndpoint !== url) {
-    solanaConnectionObject = new Connection(url, {
+    solanaConnectionObject = new Connection(url?.replace('wss', 'https'), {
       wsEndpoint: url?.replace('https', 'wss'),
     })
   }


### PR DESCRIPTION
if the user has set the rpc URL starting with wss then the Solana provider is not working. I fixed that issue and also tested with https URL, and it is working fine after this code update. as mobile has support for both wss and https